### PR TITLE
Support for light colourschemes

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -26,7 +26,12 @@
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
 CURRENT_BG='NONE'
-PRIMARY_FG=black
+
+if [[ "$AGNOSTER_LIGHT" = "1" ]]; then
+	PRIMARY_FG=white
+else
+	PRIMARY_FG=black
+fi
 
 # Characters
 SEGMENT_SEPARATOR="\ue0b0"


### PR DESCRIPTION
Setting `AGNOSTER_LIGHT` to 1 will force the theme to use light colours.

This was the easiest and cleanest method I could figure out. Since the user usually sets the `DEFAULT_USER` variable too, it shouldn't such a hassle, and light theme fans like me will be able to use agnoster without editing it.

Screenshot:
![snimka obrazovky z 2015-10-31 18-48-03](https://cloud.githubusercontent.com/assets/7472425/10865057/0ace63c0-8000-11e5-82a5-2cc37c544c4b.png)

Again, please ignore the rendering glitches, I still haven't fixed it.
