### PR TITLE
Remove prompt braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A ZSH theme optimized for people who use:
 - Git
 - Unicode-compatible fonts and terminals (I use iTerm2 + Menlo)
 
-For Mac users, I highly recommend iTerm 2 + Solarized Dark
+For Mac users, I highly recommend iTerm 2 + Solarized Dark.
 
 # Compatibility
 
@@ -16,7 +16,9 @@ To test if your terminal and font support it, check that all the necessary chara
 
 ![Character Example](https://gist.githubusercontent.com/agnoster/3712874/raw/characters.png)
 
-## What does it show?
+If you are using a Powerline-patched font, and that still doesn't look right (especially the segment separator or branch symbols), then you may be using an old, incompatible version of the Powerline-patched fonts. Download and install a current version of the font.
+
+# What does it show?
 
 - If the previous command failed (✘)
 - User @ Hostname (if user is not DEFAULT_USER, which can then be set in your profile)
@@ -29,7 +31,19 @@ To test if your terminal and font support it, check that all the necessary chara
 
 ![Screenshot](https://gist.githubusercontent.com/agnoster/3712874/raw/screenshot.png)
 
-## Future Work
+# Installation
+
+Download the files in this repo somewhere, and have your `~/.zshrc` `source` the `agnoster.zsh-theme` file.
+
+The Agnoster theme is also available through [Oh My Zsh](https://github.com/robbyrussell/oh-my-zsh/). If you have Oh My Zsh installed, just set `ZSH_THEME=agnoster` in your `~/.zshrc` before initializing OMZ.
+
+# Configuration
+
+Agnoster can be configured by setting these environment variables.
+
+* `$DEFAULT_USER` - A user name you typically log in as, and which should be omitted from the prompt display when you are that user.
+
+# Future Work
 
 I don't want to clutter it up too much, but I am toying with the idea of adding RVM (ruby version) and n (node.js version) display.
 

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -1,12 +1,15 @@
 # vim:ft=zsh ts=2 sw=2 sts=2
 #
-# agnoster's Theme - https://gist.github.com/3712874
+# agnoster's Theme - https://github.com/agnoster/agnoster-zsh-theme
 # A Powerline-inspired theme for ZSH
 #
 # # README
 #
 # In order for this theme to render correctly, you will need a
 # [Powerline-patched font](https://gist.github.com/1595572).
+# Make sure you have a recent version: the code points that Powerline
+# uses changed in 2012, and older versions will display incorrectly,
+# in confusing ways.
 #
 # In addition, I recommend the
 # [Solarized theme](https://github.com/altercation/solarized/) and, if you're
@@ -25,23 +28,42 @@
 ### Segment drawing
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
-CURRENT_BG='NONE'
 PRIMARY_FG=black
 
-# Characters
-SEGMENT_SEPARATOR="\ue0b0"
-PLUSMINUS="\u00b1"
-BRANCH="\ue0a0"
-DETACHED="\u27a6"
-CROSS="\u2718"
-LIGHTNING="\u26a1"
-GEAR="\u2699"
+# Special Powerline characters
+
+# Defines vars with the special prompt and Powerline characters
+# Use this in conjunction with "local SEGMENT_SEPARATOR BRANCH DETACHED PLUSMINUS CROSS LIGHTNING GEAR"
+# in the caller to keep from leaking these into the main shell session
+define_prompt_chars() {
+  # Force Unicode interpretation of chars, even under odd locales
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  # NOTE: This segment separator character is correct.  In 2012, Powerline changed
+  # the code points they use for their special characters. This is the new code point.
+  # If this is not working for you, you probably have an old version of the 
+  # Powerline-patched fonts installed. Download and install the new version.
+  # Do not submit PRs to change this unless you have reviewed the Powerline code point
+  # history and have new information.
+  # This is defined using a Unicode escape sequence so it is unambiguously readable, regardless of
+  # what font the user is viewing this source code in. Do not replace the
+  # escape sequence with a single literal character.
+  SEGMENT_SEPARATOR=$'\ue0b0' # 
+  PLUSMINUS=$'\u00b1'
+  BRANCH=$'\ue0a0'
+  DETACHED=$'\u27a6'
+  CROSS=$'\u2718'
+  LIGHTNING=$'\u26a1'
+  GEAR=$'\u2699'
+}
+
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
 # rendering default background/foreground.
 prompt_segment() {
   local bg fg
+  local SEGMENT_SEPARATOR BRANCH DETACHED PLUSMINUS CROSS LIGHTNING GEAR
+  define_prompt_chars
   [[ -n $1 ]] && bg="%K{$1}" || bg="%k"
   [[ -n $2 ]] && fg="%F{$2}" || fg="%f"
   if [[ $CURRENT_BG != 'NONE' && $1 != $CURRENT_BG ]]; then
@@ -55,6 +77,8 @@ prompt_segment() {
 
 # End the prompt, closing any open segments
 prompt_end() {
+  local SEGMENT_SEPARATOR BRANCH DETACHED PLUSMINUS CROSS LIGHTNING GEAR
+  define_prompt_chars
   if [[ -n $CURRENT_BG ]]; then
     print -n "%{%k%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR"
   else
@@ -78,7 +102,9 @@ prompt_context() {
 
 # Git: branch/detached head, dirty status
 prompt_git() {
-  local color ref
+  local color ref mode
+  local SEGMENT_SEPARATOR BRANCH DETACHED PLUSMINUS CROSS LIGHTNING GEAR
+  define_prompt_chars
   is_dirty() {
     test -n "$(git status --porcelain --ignore-submodules)"
   }
@@ -96,8 +122,9 @@ prompt_git() {
     else
       ref="$DETACHED ${ref/.../}"
     fi
+
     prompt_segment $color $PRIMARY_FG
-    print -Pn " $ref"
+    print -Pn " $ref$mode"
   fi
 }
 
@@ -111,6 +138,8 @@ prompt_dir() {
 # - am I root
 # - are there background jobs?
 prompt_status() {
+  local SEGMENT_SEPARATOR BRANCH DETACHED PLUSMINUS CROSS LIGHTNING GEAR
+  define_prompt_chars
   local symbols
   symbols=()
   [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}$CROSS"
@@ -120,20 +149,66 @@ prompt_status() {
   [[ -n "$symbols" ]] && prompt_segment $PRIMARY_FG default " $symbols "
 }
 
+# Mercurial repo status
+prompt_hg() {
+  local rev status
+  if $(hg id >/dev/null 2>&1); then
+    if $(hg prompt >/dev/null 2>&1); then
+      if [[ $(hg prompt "{status|unknown}") = "?" ]]; then
+        # if files are not added
+        prompt_segment red white
+        st='±'
+      elif [[ -n $(hg prompt "{status|modified}") ]]; then
+        # if any modification
+        prompt_segment yellow black
+        st='±'
+      else
+        # if working copy is clean
+        prompt_segment green black
+      fi
+      echo -n $(hg prompt "☿ {rev}@{branch}") $st
+    else
+      st=""
+      rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
+      branch=$(hg id -b 2>/dev/null)
+      if `hg st | grep -q "^\?"`; then
+        prompt_segment red black
+        st='±'
+      elif `hg st | grep -q "^[MA]"`; then
+        prompt_segment yellow black
+        st='±'
+      else
+        prompt_segment green black
+      fi
+      echo -n "☿ $rev@$branch" $st
+    fi
+  fi
+}
+
+# Virtualenv: current working virtualenv
+prompt_virtualenv() {
+  local virtualenv_path="$VIRTUAL_ENV"
+  if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
+    prompt_segment blue black "(`basename $virtualenv_path`)"
+  fi
+}
+
+
 ## Main prompt
 prompt_agnoster_main() {
   RETVAL=$?
-  CURRENT_BG='NONE'
+  local CURRENT_BG='NONE'
   prompt_status
+  prompt_virtualenv
   prompt_context
   prompt_dir
   prompt_git
+  prompt_hg
   prompt_end
 }
 
 prompt_agnoster_precmd() {
   vcs_info
-  PROMPT='%{%f%b%k%}$(prompt_agnoster_main) '
 }
 
 prompt_agnoster_setup() {
@@ -145,9 +220,15 @@ prompt_agnoster_setup() {
   add-zsh-hook precmd prompt_agnoster_precmd
 
   zstyle ':vcs_info:*' enable git
-  zstyle ':vcs_info:*' check-for-changes false
-  zstyle ':vcs_info:git*' formats '%b'
-  zstyle ':vcs_info:git*' actionformats '%b (%a)'
+  zstyle ':vcs_info:*' get-revision true
+  zstyle ':vcs_info:*' check-for-changes true
+  zstyle ':vcs_info:*' stagedstr '✚'
+  zstyle ':vcs_info:git:*' unstagedstr '●'
+  zstyle ':vcs_info:*' formats '%b'
+  zstyle ':vcs_info:*' actionformats '%b (%a)'
+
+  setopt prompt_subst
+  PROMPT='%{%f%b%k%}$(prompt_agnoster_main) '
 }
 
 prompt_agnoster_setup "$@"

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -67,9 +67,9 @@ prompt_segment() {
   [[ -n $1 ]] && bg="%K{$1}" || bg="%k"
   [[ -n $2 ]] && fg="%F{$2}" || fg="%f"
   if [[ $CURRENT_BG != 'NONE' && $1 != $CURRENT_BG ]]; then
-    print -n "%{$bg%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR%{$fg%}"
+    print -n "$bg%F{$CURRENT_BG}$SEGMENT_SEPARATOR$fg"
   else
-    print -n "%{$bg%}%{$fg%}"
+    print -n "$bg$fg"
   fi
   CURRENT_BG=$1
   [[ -n $3 ]] && print -n $3
@@ -80,11 +80,11 @@ prompt_end() {
   local SEGMENT_SEPARATOR BRANCH DETACHED PLUSMINUS CROSS LIGHTNING GEAR
   define_prompt_chars
   if [[ -n $CURRENT_BG ]]; then
-    print -n "%{%k%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR"
+    print -n "%k%F{$CURRENT_BG}$SEGMENT_SEPARATOR"
   else
-    print -n "%{%k%}"
+    print -n "%k"
   fi
-  print -n "%{%f%}"
+  print -n "%f"
   CURRENT_BG=''
 }
 
@@ -96,7 +96,7 @@ prompt_context() {
   local user=`whoami`
 
   if [[ "$user" != "$DEFAULT_USER" || -n "$SSH_CONNECTION" ]]; then
-    prompt_segment $PRIMARY_FG default " %(!.%{%F{yellow}%}.)$user@%m "
+    prompt_segment $PRIMARY_FG default " %(!.%F{yellow}.)$user@%m "
   fi
 }
 
@@ -142,9 +142,9 @@ prompt_status() {
   define_prompt_chars
   local symbols
   symbols=()
-  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}$CROSS"
-  [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}$LIGHTNING"
-  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}$GEAR"
+  [[ $RETVAL -ne 0 ]] && symbols+="%F{red}$CROSS"
+  [[ $UID -eq 0 ]] && symbols+="%F{yellow}$LIGHTNING"
+  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%F{cyan}$GEAR"
 
   [[ -n "$symbols" ]] && prompt_segment $PRIMARY_FG default " $symbols "
 }
@@ -228,7 +228,7 @@ prompt_agnoster_setup() {
   zstyle ':vcs_info:*' actionformats '%b (%a)'
 
   setopt prompt_subst
-  PROMPT='%{%f%b%k%}$(prompt_agnoster_main) '
+  PROMPT='%f%b%k$(prompt_agnoster_main) '
 }
 
 prompt_agnoster_setup "$@"


### PR DESCRIPTION
Note: This PR depends on and includes #5.

The `%{...%}` quotes denote non-printing characters in prompts. But zsh's %F, %K, and related % prompt sequences already know they are non-printing, so you don't need to protect those. The `%{...%}` is only needed when you are directly emitting terminal control sequences or other zero-width characters.

Removing them improves readability, I think.
