### PR TITLE
Set PROMPT_SUBST during setup

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -140,6 +140,7 @@ prompt_agnoster_setup() {
   autoload -Uz add-zsh-hook
   autoload -Uz vcs_info
 
+  setopt PROMPT_SUBST
   prompt_opts=(cr subst percent)
 
   add-zsh-hook precmd prompt_agnoster_precmd


### PR DESCRIPTION
Without this, the prompt is simply `$(prompt_agnoster_main)` (literally).
