### PR TITLE
Adding remote URL path to be displayed after branch head

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -83,6 +83,7 @@ prompt_git() {
     test -n "$(git status --porcelain --ignore-submodules)"
   }
   ref="$vcs_info_msg_0_"
+  remote_path=$(git config --get remote.origin.url)
   if [[ -n "$ref" ]]; then
     if is_dirty; then
       color=yellow
@@ -97,7 +98,7 @@ prompt_git() {
       ref="$DETACHED ${ref/.../}"
     fi
     prompt_segment $color $PRIMARY_FG
-    print -Pn " $ref"
+    print -Pn " $ref $remote_path"
   fi
 }
 


### PR DESCRIPTION
I have enabled remote url path of the current working repository ,to be displayed after branch name.This is just to make sure on which repository ur in