### PR TITLE
Include python virtual environment feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To test if your terminal and font support it, check that all the necessary chara
   - Dirty working directory (±, color change)
 - Working directory
 - Elevated (root) privileges (⚡)
+- Name of the currently active python virtual environment
 
 ![Screenshot](https://gist.githubusercontent.com/agnoster/3712874/raw/screenshot.png)
 


### PR DESCRIPTION
Noticed that the README does not include the feature I last added. Thought it would be good to display it in the summary of features for people looking to gauge what this theme can do.

@agnoster 
