### PR TITLE
[path] add option to use a short path instead of full relative

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -28,6 +28,10 @@
 CURRENT_BG='NONE'
 PRIMARY_FG=black
 
+# if AGNOSTER_SHORT_PATH is set use %1~ for the path value
+# that will turn '~/.oh-my-zsh/custom/themes' in to 'themes'
+[ -n "${AGNOSTER_SHORT_PATH}" ] && AGNOSTER_CURRENT_PATH=' %1~ '
+
 # Characters
 SEGMENT_SEPARATOR="\ue0b0"
 PLUSMINUS="\u00b1"
@@ -103,7 +107,8 @@ prompt_git() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue $PRIMARY_FG ' %~ '
+  local current_path=${AGNOSTER_CURRENT_PATH:=' %~ '}
+  prompt_segment blue $PRIMARY_FG "${current_path}"
 }
 
 # Status:


### PR DESCRIPTION
This change to the `agnoster` theme adds an option for using the name of
the current directory instead of a relative path. Assume you're in the
following directory: `~/projects/agnoster-zsh-theme`. If you set
`AGNOSTER_SHORT_PATH=1` in your `.zshrc` file, the path will render only
as `agnoster-zsh-theme` on the command line instead of
`~/projects/agnoster-zsh-theme`.

In the implementation of this option, another was added to give you even
more control if you want it (`AGNOSTER_CURRENT_PATH`). If
`AGNOSTER_SHORT_PATH` is unset and `AGNOSTER_CURRENT_PATH` is set, that
value will be used for the path value on the prompt.