### PR TITLE
Moved git-info right after user@host and moved cursor on a new line

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -27,7 +27,7 @@
 
 CURRENT_BG='NONE'
 if [[ -z "$PRIMARY_FG" ]]; then
-	PRIMARY_FG=black
+  PRIMARY_FG=black
 fi
 
 # Characters
@@ -131,15 +131,22 @@ prompt_virtualenv() {
   fi
 }
 
+# Put cursor on a new line
+prompt_cursor(){
+  prompt_segment
+  print -n "\n$SEGMENT_SEPARATOR"
+}
+
 ## Main prompt
 prompt_agnoster_main() {
   RETVAL=$?
   CURRENT_BG='NONE'
   prompt_status
   prompt_context
+  prompt_git
   prompt_virtualenv
   prompt_dir
-  prompt_git
+  prompt_cursor
   prompt_end
 }
 


### PR DESCRIPTION
**Why did you do it?**
1. Moving git-info makes sense because it's a better visual anchor, it's after a fixed width section (user@host) and you don't have to adjust when you change your git project.
2. Putting cursor on a new line also because it's a better anchor (always at the beginning of the line) and because I often find myself not having enough space to see the command properly because the path was to big and the command jumped on 2 lines.

**What exactly did you do?**
Changed the order in `prompt_agnoster_main` and added a new `prompt_cursor` function.