### PR TITLE
Update git prompt to not give error messages

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -82,7 +82,7 @@ prompt_context() {
 prompt_git() {
   local color ref
   is_dirty() {
-    test -n "$(git status --porcelain --ignore-submodules)"
+    test -n "$(git status --porcelain --ignore-submodules &> /dev/null)"
   }
   ref="$vcs_info_msg_0_"
   if [[ -n "$ref" ]]; then


### PR DESCRIPTION
The prompt outputs

    fatal: This operation must be run in a work tree

Inside the .git folder. This suppresses output of this command.