### PR TITLE
Add back the prompt_sp option for zsh >= 5.4.1

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -152,7 +152,7 @@ prompt_agnoster_setup() {
   autoload -Uz add-zsh-hook
   autoload -Uz vcs_info
 
-  prompt_opts=(cr subst percent)
+  prompt_opts=(cr percent sp subst)
 
   add-zsh-hook precmd prompt_agnoster_precmd
 


### PR DESCRIPTION
In 5.4.1, this options was reset between prompts, so to retain the
previous default behavior, this should be added back.

This was the change which caused it to be reset: https://github.com/zsh-users/zsh/commit/43e55a9bcd2c90124a751f2597d2f33cb6e3c042#diff-bb10d67e7a8561b66a53a805f3c77a40R233

This is the documentation on the option itself: http://zsh.sourceforge.net/Doc/Release/Options.html#Prompting