### PR TITLE
Add support for 'vaulted' shells

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -131,6 +131,34 @@ prompt_virtualenv() {
   fi
 }
 
+epoch_date() {
+  unamestr=`uname`
+  if [[ "$unamestr" == 'Linux' ]]; then
+    echo $(date -d $1 +%s)
+  elif [[ "$unamestr" == 'Darwin' ]]; then
+    echo $(date -j -f %Y-%m-%dT%H:%M:%S%z $1 +%s)
+  else # TODO - other platforms?
+    echo $(date -j -f %Y-%m-%dT%H:%M:%S%z $1 +%s)
+  fi
+}
+
+# vaulted: current vaulted shell
+prompt_vaulted() {
+  if [[ -z $VAULTED_ENV ]]; then
+    return
+  fi
+  local exp=$(echo $VAULTED_ENV_EXPIRATION | sed 's/Z/+0000/')
+  local valid_until=$(epoch_date $exp)
+  local bg=009 #orange
+  local fg=black
+  if [[ $valid_until -lt $(date +%s) ]]; then
+    fg=blue
+  fi
+  if [[ -n $VAULTED_ENV ]]; then
+    prompt_segment $bg $fg "$VAULTED_ENV"
+  fi
+}
+
 ## Main prompt
 prompt_agnoster_main() {
   RETVAL=$?
@@ -138,6 +166,7 @@ prompt_agnoster_main() {
   prompt_status
   prompt_context
   prompt_virtualenv
+  prompt_vaulted
   prompt_dir
   prompt_git
   prompt_end


### PR DESCRIPTION
If a user is currently in a [vaulted](github.com/miquella/vaulted)
shell, they will now have an indication of this in the agnoster prompt,
not unlike the virtualenv prompt. The foreground color will switch if
the timer expires (which usually signifies that the temporary Amazon
keys generated by vaulted will be invalid).