### PR TITLE
Flexible directory path length

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -105,7 +105,7 @@ prompt_git() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue $PRIMARY_FG ' %~ '
+  prompt_segment blue $PRIMARY_FG " %-53<...<%~%<< "
 }
 
 # Status:


### PR DESCRIPTION
Directory path doesn't take multiple lines, instead it is trying to leave 53 chars available for everything else truncating from the directory start with ...