### PR TITLE
Set prompt options when not loaded by promptinit

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -153,6 +153,10 @@ prompt_agnoster_setup() {
   autoload -Uz vcs_info
 
   prompt_opts=(cr subst percent)
+  
+  # borrowed from promptinit, sets the prompt options in case pure was not
+  # initialized via promptinit.
+  setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
 
   add-zsh-hook precmd prompt_agnoster_precmd
 


### PR DESCRIPTION
Will set prompt options when loaded by zgen and posibly other plugin managers for zsh without oh-my-zsh

Fixes #35 
Closes #46