### PR TITLE
Display diff from remote repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ To test if your terminal and font support it, check that all the necessary chara
 - Current python venv prompt
 - Commit diff from remote
 - A snake emoji if a venv is activated
-
+![Fork specific screenshot](https://user-images.githubusercontent.com/6463334/51431140-74c9d080-1c2d-11e9-89e5-42e05cad9f77.png)
 ![Screenshot](https://gist.githubusercontent.com/agnoster/3712874/raw/screenshot.png)

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ A ZSH theme optimized for people who use:
 - Solarized
 - Git
 - Unicode-compatible fonts and terminals (I use iTerm2 + Menlo)
+- Python3 and the builtin `venv` module
 
 For Mac users, I highly recommend iTerm 2 + Solarized Dark
 
-# Compatibility
-
-**NOTE:** In all likelihood, you will need to install a [Powerline-patched font](https://github.com/Lokaltog/powerline-fonts) for this theme to render correctly.
+**NOTE:** This needs a [Powerline-patched font](https://github.com/Lokaltog/powerline-fonts) for this theme to render correctly I reccomend [Fira Code](https://github.com/tonsky/FiraCode).
 
 To test if your terminal and font support it, check that all the necessary characters are supported by copying the following command to your terminal: `echo "\ue0b0 \u00b1 \ue0a0 \u27a6 \u2718 \u26a1 \u2699"`. The result should look like this:
 
@@ -26,15 +25,9 @@ To test if your terminal and font support it, check that all the necessary chara
   - Dirty working directory (±, color change)
 - Working directory
 - Elevated (root) privileges (⚡)
+#### Fork only:
+- Current python venv prompt
+- Commit diff from remote
+- A snake emoji if a venv is activated
 
 ![Screenshot](https://gist.githubusercontent.com/agnoster/3712874/raw/screenshot.png)
-
-## Future Work
-
-I don't want to clutter it up too much, but I am toying with the idea of adding RVM (ruby version) and n (node.js version) display.
-
-It's currently hideously slow, especially inside a git repo. I guess it's not overly so for comparable themes, but it bugs me, and I'd love to hear ideas about how to improve the performance.
-
-Would be nice for the code to be a bit more sane and re-usable. Something to easily append a section with a given FG/BG, and add the correct opening and closing.
-
-Also the dependency on a powerline-patched font is regrettable, but there's really no way to get that effect without it. Ideally there would be a way to check for compatibility, or maybe even fall back to one of the similar unicode glyphs.

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -38,7 +38,7 @@ DETACHED="\u27a6"
 CROSS="\u2718"
 LIGHTNING="\u26a1"
 GEAR="\u2699"
-SNAKE="$emoji[snake]"
+SNAKE="🐍"
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -38,6 +38,7 @@ DETACHED="\u27a6"
 CROSS="\u2718"
 LIGHTNING="\u26a1"
 GEAR="\u2699"
+SNAKE="$emoji[snake]"
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -134,10 +135,11 @@ prompt_status() {
 # Display current virtual environment
 prompt_virtualenv() {
   if [[ -n $VIRTUAL_ENV ]]; then
-    virt_prompt=$(grep -oiE "x\(.+\)" $VIRTUAL_ENV/bin/activate|cut  -c3-|rev|cut -c2-|rev)
+    virt_prompt=$(grep -oiE "x\(.+\)" $VIRTUAL_ENV/bin/activate 2>/dev/null |cut  -c3-|rev|cut -c2-|rev)
+    # [ -z $virt_prompt ] && virt_prompt=$(basename $VIRTUAL_ENV)
     color=cyan
     prompt_segment $color $PRIMARY_FG
-    print -n " $virt_prompt"
+    print -Pn " $SNAKE $virt_prompt"
   fi
 }
 

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -100,6 +100,15 @@ prompt_git() {
     fi
     prompt_segment $color $PRIMARY_FG
     print -n " $ref"
+    # Print diff from remote
+    ahead=$(git_commits_ahead)
+    behind=$(git_commits_behind)
+    if [ -n "$ahead" ]; then
+      print -n " ↑$ahead"
+    fi
+    if [ -n "$behind" ]; then
+      print -n " ↓$behind"
+    fi
   fi
 }
 

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -134,9 +134,10 @@ prompt_status() {
 # Display current virtual environment
 prompt_virtualenv() {
   if [[ -n $VIRTUAL_ENV ]]; then
+    virt_prompt=$(grep -oiE "x\(.+\)" $VIRTUAL_ENV/bin/activate|cut  -c3-)
     color=cyan
     prompt_segment $color $PRIMARY_FG
-    print -Pn " $(basename $VIRTUAL_ENV) "
+    print -n " $virt_prompt"
   fi
 }
 

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -134,7 +134,7 @@ prompt_status() {
 # Display current virtual environment
 prompt_virtualenv() {
   if [[ -n $VIRTUAL_ENV ]]; then
-    virt_prompt=$(grep -oiE "x\(.+\)" $VIRTUAL_ENV/bin/activate|cut  -c3-)
+    virt_prompt=$(grep -oiE "x\(.+\)" $VIRTUAL_ENV/bin/activate|cut  -c3-|rev|cut -c2-|rev)
     color=cyan
     prompt_segment $color $PRIMARY_FG
     print -n " $virt_prompt"


### PR DESCRIPTION
Starting from this commit,the git prompt will show the difference between
the local and remote repositories.

Looking at [`git_commits_ahead`](https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/git.zsh#L78) it doesn't seem to call `git fetch` so there shouldn't be major slowdowns due to network use.

<img width="434" alt="image" src="https://user-images.githubusercontent.com/6463334/44326779-70726f00-a465-11e8-97d8-70ce20e943bf.png">

Closes #82 