### PR TITLE
Display custom venv prompt

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -100,6 +100,15 @@ prompt_git() {
     fi
     prompt_segment $color $PRIMARY_FG
     print -n " $ref"
+    # Print diff from remote
+    ahead=$(git_commits_ahead)
+    behind=$(git_commits_behind)
+    if [ -n "$ahead" ]; then
+      print -n " ↑$ahead"
+    fi
+    if [ -n "$behind" ]; then
+      print -n " ↓$behind"
+    fi
   fi
 }
 

--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -134,9 +134,10 @@ prompt_status() {
 # Display current virtual environment
 prompt_virtualenv() {
   if [[ -n $VIRTUAL_ENV ]]; then
+    virt_prompt=$(grep -oiE "x\(.+\)" $VIRTUAL_ENV/bin/activate|cut  -c3-)
     color=cyan
     prompt_segment $color $PRIMARY_FG
-    print -Pn " $(basename $VIRTUAL_ENV) "
+    print -n " $virt_prompt"
   fi
 }
 


### PR DESCRIPTION
This is how it looks
![venv](https://user-images.githubusercontent.com/6463334/44393278-e990c580-a53c-11e8-92ef-0c5472211e13.gif)
Right now there isn't an official value to access the custom prompt so it is (poorly) extracted from the activation script.
- [ ] This might break with `virtualenv` and needs to be tested.