### PR TITLE
Adds kubernetes prompt segment including default context and namespace.

### DIFF
--- a/agnoster.zsh-theme
+++ b/agnoster.zsh-theme
@@ -133,6 +133,19 @@ prompt_status() {
   [[ -n "$symbols" ]] && prompt_segment $PRIMARY_FG default " $symbols "
 }
 
+# K8s:
+# - display current default namespace and context
+prompt_k8s() {
+  # break without kubectx/kubens installed or if configured to not show
+  ! [[ -x "$(command -v kubectx)" && -x "$(command -v kubens)" && -z ${DISABLE_K8S_PROMPT+x} ]] && return
+
+  # get namespace and context defaults
+
+  K8S_CONTEXT=$(kubectx -c)
+  K8S_NAMESPACE=$(kubens -c)
+  prompt_segment red yellow  "K8S: $K8S_CONTEXT ($K8S_NAMESPACE)"
+}
+
 # Display current virtual environment
 prompt_virtualenv() {
   if [[ -n $VIRTUAL_ENV ]]; then


### PR DESCRIPTION
This adds a new prompt segment which includes the default kubernetes context and namespace. These are implicitly added to every interaction with kubernetes, and I have found it useful to include them in my prompt to avoid accidents. 

The segment depends on two executable Go binaries (kubectx and kubens) located [here](https://github.com/ahmetb/kubectx). It will not display if either binary is not executable, and it can be disabled by setting DISABLE_K8S_PROMPT in your environment.